### PR TITLE
Adds progress bar

### DIFF
--- a/resources/translations/translations.de.js
+++ b/resources/translations/translations.de.js
@@ -406,7 +406,8 @@ module.exports = {
     "NO_POSITION": "Keine Position",
     "SELECT_A_CHALLENGE": "Eine Challenge auswählen",
     "WANT_TO_FULFILL_CHALLENGE": "Du willst damit eine Challenge erfüllen?",
-    "NOW": "Jetzt?"
+    "NOW": "Jetzt?",
+    "SERVER_PROCESSING_REQUEST":"Medium wird vom Server verarbeitet, gib uns einen kurzen Moment!"
   },
   "MASTER": {
     "BACK_TO_REGISTER": "Rolle auswählen",

--- a/resources/translations/translations.en.js
+++ b/resources/translations/translations.en.js
@@ -406,7 +406,8 @@ module.exports = {
     "NO_POSITION": "No position",
     "SELECT_A_CHALLENGE": "Select a challenge",
     "WANT_TO_FULFILL_CHALLENGE": "Do you want to fulfill a challenge with this posting?",
-    "NOW": "Now?"
+    "NOW": "Now?",
+    "SERVER_PROCESSING_REQUEST":"Medium is being processed by the server, give us a moment!"
   },
   "MASTER": {
     "BACK_TO_REGISTER": "Select role",

--- a/src/less/_teampage.less
+++ b/src/less/_teampage.less
@@ -152,6 +152,30 @@
   text-align: center;
 }
 
+.bo-team-upload-progress {
+  width: 100%;
+  height: 15px;
+}
+
+.bo-team-upload-progress-wrap {
+  background: transparent;
+  overflow: hidden;
+  position: relative;
+  display: none;
+  .bo-team-upload-progress-bar {
+    background: #e6823c;
+    left: -100%;
+    position: absolute;
+    top: 0;
+    transition: 0.3s;
+  }
+}
+
+.bo-team-upload-server-processing {
+  display: none;
+  margin: 10px 18px;
+}
+
 .bo-team-post-icon {
   margin-top: 40px;
 }

--- a/views/dynamic/team/team-detail.handlebars
+++ b/views/dynamic/team/team-detail.handlebars
@@ -69,6 +69,12 @@
                                         <i class="material-icons bo-team-post-icon">camera_alt</i><br/>
                                         <span class="bo-team-post-upload-text"></span>
                                     </div>
+                                    <div class="bo-team-upload-progress-wrap bo-team-upload-progress" data-progress-percent="25">
+                                        <div class="bo-team-upload-progress-bar bo-team-upload-progress"></div>
+                                    </div>
+                                </div>
+                                <div class="alert alert-info bo-team-upload-server-processing">
+                                    {{__ 'SERVER_PROCESSING_REQUEST'}}
                                 </div>
                                 <div class="bo-card-content">
                                     <div class="form-group">


### PR DESCRIPTION
Adds a progress bar for the media upload on the team page. Only client side upload is covered but a small info alert is displayed to keep the user waiting while the node server has time to process the request.

Also a small bug was fixed where the image preview was not working properly when the images where bigger than the screen (so basically 99% of the images).