### PR TITLE
Display stacktrace on error page if enabled in config

### DIFF
--- a/config-template.json
+++ b/config-template.json
@@ -31,5 +31,8 @@
     "enabled": false,
     "key": "example-key-123",
     "project": "1234"
+  },
+  "debug": {
+    "displayStackTrace": true
   }
 }

--- a/src/server/views/layouts/error.handlebars
+++ b/src/server/views/layouts/error.handlebars
@@ -77,8 +77,8 @@
 
     <h1>Error {{code}}</h1>
     <h4>{{message}}</h4>
-    {{#if error}}
-        <p>{{error}}</p>
+    {{#if stacktrace}}
+        <p style="font-family: monospace">{{{stacktrace}}}</p>
     {{/if}}
 
     <p>Sorry for that! Try <a href="/logout">logging out</a> and logging back in again. If this problem persists please contact our support at <a href="mailto:event@break-out.org">event@break-out.org</a>.</p>


### PR DESCRIPTION
This will display the stacktrace of an error on the error page if it is enabled via the config.

The changes:
* Display stacktrace
* Enable this feature via config file instead of depending on the specific NODE_ENVIRONMENT