### PR TITLE
En-/disable sentry based on config

### DIFF
--- a/config-template.json
+++ b/config-template.json
@@ -26,5 +26,10 @@
     "baseUrl": "localhost:8082",
     "clientId": "client_app",
     "clientSecret": "123456789"
+  },
+  "sentry": {
+    "enabled": false,
+    "key": "example-key-123",
+    "project": "1234"
   }
 }

--- a/services/helpers.js
+++ b/services/helpers.js
@@ -8,6 +8,7 @@ const Remarkable = require('remarkable');
 const path = require('path');
 const logger = require('../services/logger');
 const config = require('../config/config');
+const _ = require('lodash');
 
 // Setup
 const md = new Remarkable({
@@ -453,5 +454,47 @@ exports.isNewerTenMinutes = (date, context) => {
     return context.fn(this);
   } else {
     return context.inverse(this);
+  }
+};
+
+/**
+ * This handlebars helper will render a block in the handlerbars file if the config value is true
+ *
+ * Example:
+ *
+ * {{#isEnabled 'printHeadline.enabled'}} <h1>I am a headline </h1> {{/isEnabled}}
+ *
+ * @param key The config key to look up
+ * @param context Handlebars context
+ * @returns {string} Either the block to be rendered or an empty string
+ */
+exports.isEnabled = function (key, context) {
+
+  const value = _.get(config, key);
+
+  if (value === true) {
+    return context.fn(this);
+  } else if (value === false) {
+    return '';
+  } else {
+    throw new Error(`Found value '${value}' for config key '${key}'. Expected boolean value`);
+  }
+};
+
+/**
+ * Returns the value for a key from the config file
+ *
+ * Example: {{config 'backend.accessToken'}} will render the accessToken into the handlebars file
+ *
+ * @param key The config key to look up
+ * @param context Handlebars context
+ * @returns {*} The value found for the given key
+ */
+exports.config = function (key, context) {
+  const value = _.get(config, key);
+  if (value) {
+    return value;
+  } else {
+    throw new Error(`Couldn't find value for key '${key}' in configuration`);
   }
 };

--- a/views/partials/head-content.handlebars
+++ b/views/partials/head-content.handlebars
@@ -61,10 +61,12 @@
 
 <!-- End Google Tag Manager -->
 
-<script src="https://cdn.ravenjs.com/3.15.0/raven.min.js"></script>
-<script type="text/javascript">
-    Raven.config('https://1571b6796c7e44c2b85449d4a329c38a@sentry.io/172597').install()
-</script>
+{{#isEnabled 'sentry.enabled'}}
+    <script src="https://cdn.ravenjs.com/3.15.0/raven.min.js"></script>
+    <script type="text/javascript">
+        Raven.config('https://{{config 'sentry.key'}}@sentry.io/{{config 'sentry.project'}}').install()
+    </script>
+{{/isEnabled}}
 
 {{#each requirements}}
     <script type="text/javascript" src="/js/{{this}}.js"></script>


### PR DESCRIPTION
This enables sentry based on your configuration file by introducing two new handlebars helpers called `isEnabled` and `config`