### PR TITLE
#289: check if new sponsorings are allowed for event

### DIFF
--- a/src/client/js/sponsoring.js
+++ b/src/client/js/sponsoring.js
@@ -111,23 +111,6 @@ $(document).ready(() => {
 
   });
 
-  $('#bo-add-challenge-model-btn').click((e) => {
-    alert('Eintragen von Sponsoren ist nach dem Event nicht mehr möglich');
-    e.stopImmediatePropagation();
-  });
-
-
-  $('#bo-add-sponsoring-model-btn').click((e) => {
-    alert('Eintragen von Challenges ist nach dem Event nicht mehr möglich');
-    e.stopImmediatePropagation();
-  });
-
-  $('#bo-add-offline-sponsoring-model-btn').click((e) => {
-    alert('Eintragen von Sponsoren ist nach dem Event nicht mehr möglich');
-    e.stopImmediatePropagation();
-  });
-
-
   $('#editSponsoringModal').submit(function (e) {
     e.preventDefault();
     if (sanityCheck('editSponsoringModal')) {

--- a/src/common/resources/translations/translations.de.js
+++ b/src/common/resources/translations/translations.de.js
@@ -373,7 +373,12 @@ module.exports = {
   },
   "CLOSED": {
     "HEADLINE": "Anmeldung geschlossen",
-    "DESCRIPTION": "Leider ist die Anmeldung als Teilnehmer bei BreakOut 2018 nicht mehr offen :( Du kannst dich aber noch als Sponsor anmelden und so den EinDollarBrille e.V. unterstützen. Trage dich doch in unseren Newsletter ein, um beim nächsten safe BreakOut dabei zu sein!",
+    "DESCRIPTION": "Leider ist die Anmeldung als Teilnehmer bei BreakOut 2018 gerade nicht geöffnet :( Trag dich aber gerne in unseren Newsletter ein, um immer auf dem aktuellsten Stand zu bleiben!",
+    "LINK_DESCRIPTION": "ZURÜCK ZUR WEBSEITE"
+  },
+  "SPONSOR-CLOSED": {
+    "HEADLINE": "Sponsoren-Anmeldung geschlossen",
+    "DESCRIPTION": "Leider ist die Registrierung als Sponsor bei BreakOut 2018 gerade nicht geöffnet :(",
     "LINK_DESCRIPTION": "ZURÜCK ZUR WEBSEITE"
   },
   "MESSAGE": {

--- a/src/common/resources/translations/translations.de.js
+++ b/src/common/resources/translations/translations.de.js
@@ -368,7 +368,8 @@ module.exports = {
     "STATUS_WITHDRAWN": "Zurückgezogen",
     "LABEL_EMAIL": "Emailadresse des Sponsors (optional)",
     "ESTIMATED_DONATE_PROMISE": "Geschätztes Spendenversprechen",
-    "SELECT_TEAM": "Team auswählen"
+    "SELECT_TEAM": "Team auswählen",
+    'NO_NEW_SPONSORINGS': 'Momentan können keine Sponsorings eingetragen werden.'
   },
   "CLOSED": {
     "HEADLINE": "Anmeldung geschlossen",

--- a/src/common/resources/translations/translations.en.js
+++ b/src/common/resources/translations/translations.en.js
@@ -368,7 +368,8 @@ module.exports = {
     "STATUS_WITHDRAWN": "Withdrawn",
     "LABEL_EMAIL": "Email address of sponsor (optional)",
     "ESTIMATED_DONATE_PROMISE": "Estimated donate promise",
-    "SELECT_TEAM": "Select team"
+    "SELECT_TEAM": "Select team",
+    "NO_NEW_SPONSORINGS": "At the moment it is not possible to add a sponsoring."
   },
   "CLOSED": {
     "HEADLINE": "Registration closed",

--- a/src/common/resources/translations/translations.en.js
+++ b/src/common/resources/translations/translations.en.js
@@ -373,8 +373,13 @@ module.exports = {
   },
   "CLOSED": {
     "HEADLINE": "Registration closed",
-    "DESCRIPTION": "The registration for BreakOut 2018 is closed :( You can still register as a sponsor and support One Dollar Glasses. Sign up for our newsletter to make sure you don't miss the next BreakOut.",
+    "DESCRIPTION": "The registration for BreakOut 2018 is currently closed :( Sign up for our newsletter to make sure you don't miss any news about BreakOut.",
     "LINK_DESCRIPTION": "BACK TO THE WEBSITE"
+  },
+  "SPONSOR-CLOSED": {
+    "HEADLINE": "Registration for Sponsors closed",
+    "DESCRIPTION": "The registration as a sponsor is currently closed :(",
+    "LINK_DESCRIPTION": "ZURÜCK ZUR WEBSEITE"
   },
   "MESSAGE": {
     "HEADLINE": "Messages",

--- a/src/server/controller/SponsoringController.js
+++ b/src/server/controller/SponsoringController.js
@@ -392,4 +392,13 @@ sponsoring.invoice.getByTeam = (req) => co(function*() {
   throw ex;
 });
 
+sponsoring.sponsoringIsOpenForAnyEvent = (req, res, next) => co(function *(){
+  const events = yield api.event.all();
+  if (events.some(event => event.allowNewSponsoring)) {
+    next();
+  } else {
+    res.redirect('/sponsor-closed');
+  }
+});
+
 module.exports = sponsoring;

--- a/src/server/controller/SponsoringController.js
+++ b/src/server/controller/SponsoringController.js
@@ -54,22 +54,23 @@ sponsoring.showSponsorings = function*(req, res) {
   let outSponsoring = [];
   let outChallenges = [];
   let confirmedDonations = [];
-  //INCOMING
+  let teams = [];
 
+  //INCOMING
   if (req.user.status.is.team) {
     incSponsoring = yield sponsoring.getByTeam(req);
     incChallenges = yield sponsoring.challenge.getByTeam(req);
     confirmedDonations = yield sponsoring.invoice.getByTeam(req);
+    req.user.me.participant.event = yield api.event.get(req.user.me.participant.eventId);
   }
 
   //OUTGOING
   if (req.user.status.is.sponsor) {
     outSponsoring = yield sponsoring.getBySponsor(req);
     outChallenges = yield sponsoring.challenge.getBySponsor(req);
+    teams = yield sponsoring.getAllTeamsSummary(req);
+    teams = teams.filter(team => team.eventAllowNewSponsoring);
   }
-
-
-  const teams = yield sponsoring.getAllTeamsSummary(req);
 
   res.render('dynamic/sponsoring/sponsoring', {
     error: req.flash('error'),

--- a/src/server/routes/dynamic.js
+++ b/src/server/routes/dynamic.js
@@ -4,6 +4,7 @@ const DynamicController = require('../controller/DynamicController');
 const AuthenticationController = require('../controller/AuthenticationController');
 const StaticController = require('../controller/StaticController.js');
 const TeamController = require('../controller/TeamController');
+const SponsoringController = require('../controller/SponsoringController');
 
 const Router = require('co-router');
 const multer = require('multer');
@@ -50,7 +51,9 @@ router.get('/reset/:email/:token', funnelTemplate('reset-pw'));
 
 router.get('/closed', funnelTemplate('closed'));
 
-router.get('/sponsor', session.isUser, redirectIfSponsor, funnelTemplate('sponsor'));
+router.get('/sponsor-closed', funnelTemplate('sponsor-closed'));
+
+router.get('/sponsor', session.isUser, SponsoringController.sponsoringIsOpenForAnyEvent, redirectIfSponsor, funnelTemplate('sponsor'));
 
 router.get('/login', StaticController.renderLandingpage); // client-side routing
 

--- a/src/server/views/dynamic/register/sponsor-closed.handlebars
+++ b/src/server/views/dynamic/register/sponsor-closed.handlebars
@@ -1,0 +1,27 @@
+<div class="container">
+    <div class="col-sm-4 registration-box-border div-align-mid">
+        <div class="row registration-margin">
+            <div class="col-md-10 div-align-mid">
+                <img class="bo-modal-logo center" alt="BreakOut" src="/img/logos/BreakOut-Logo_Header.svg">
+            </div>
+        </div>
+        <div class="row registration-margin">
+            <div class="col-xs-12 text-center">
+                <h2>{{__ 'HEADLINE'}}</h2>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-xs-12">
+                <p>{{__ 'DESCRIPTION'}}</p>
+            </div>
+        </div>
+
+        <div class="row registration-margin">
+            <div class="col-xs-12 text-center">
+                <a href="http://break-out.org" class="no-underline">
+                    <button class="btn btn-primary btn-block">{{__ 'LINK_DESCRIPTION'}}</button>
+                </a>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/server/views/dynamic/sponsoring/sponsoring.handlebars
+++ b/src/server/views/dynamic/sponsoring/sponsoring.handlebars
@@ -345,81 +345,90 @@
 <div class="modal" id="addSponsoring" tabindex="-1" role="dialog" aria-labelledby="addModalTitle" {{#weakIfCond mode 2}} data-showReferrer="true" {{/weakIfCond}}>
     <div class="modal-dialog" role="document">
         <div class="modal-content">
-            <form class="form" id="addSponsoringModal">
-                <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
-                            aria-hidden="true">&times;</span></button>
-                    <h3 class="modal-title" id="addModalTitle">{{__ 'BTN_ADD'}}</h3>
-                </div>
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
+                        aria-hidden="true">&times;</span></button>
+                <h3 class="modal-title" id="addModalTitle">{{__ 'BTN_ADD'}}</h3>
+            </div>
+            {{#if teams.length}}
+                <form class="form" id="addSponsoringModal">
+
+                    <div class="modal-body">
+                        <div class="row">
+                            <div class="col-xs-12" id="addResult"></div>
+                        </div>
+                        <div class="row">
+                            <div class="col-xs-12">
+                                <p>{{__ 'ADD_MODAL_CONTENT'}}</p>
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-xs-12">
+                                <div class="form-group">
+                                    <select name="team" id="team_select" class="form-control"
+                                            required="required">
+                                        <!-- TODO: l10n -->
+                                        <option disabled selected>{{__ 'SELECT_TEAM'}}</option>
+                                        {{#each teams}}
+                                            <option value='{"team": "{{teamId}}", "event": "{{eventId}}"}' {{#weakIfCond ../fromTeam teamId}} selected="selected" {{/weakIfCond}}>
+                                                {{teamName}} ({{teamId}}) ({{eventTitle}})
+                                            </option>
+                                        {{/each}}
+
+                                    </select>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-sm-8 hidden-xs">
+                                <div class="form-group">
+                                    <label for="amountPerKm_range">{{__ 'LABEL_AMOUNT_KM'}}</label>
+                                    <input id="amountPerKm_range" type="range" name="amountPerKm_range" class="form-control"
+                                           min="0.01" max="2" step="0.01"
+                                           value="0.3" required="required">
+                                </div>
+                            </div>
+                            <div class="col-sm-4">
+                                <div class="form-group">
+                                    <label for="amountPerKm_text">{{__ 'LABEL_AMOUNT_KM'}}</label>
+                                    <input type="text" class="form-control" name="amountPerKm_text"
+                                           id="amountPerKm_text" required="required" value="0.30"
+                                           placeholder="{{__ 'LABEL_AMOUNT_KM'}}">
+                                </div>
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-xs-12">
+                                <div class="form-group">
+                                    <label for="limit">{{__ 'LABEL_LIMIT'}}</label>
+                                    <input type="text" class="form-control" name="limit"
+                                           id="limit"
+                                           placeholder="{{__ 'LABEL_LIMIT'}}">
+                                </div>
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-xs-12">
+                                <div class="well" id="output">
+
+                                </div>
+                                <h4 class="text-right">{{__ 'ESTIMATED_DONATE_PROMISE'}}: <strong><span
+                                        id="estimate"></span>€</strong></h4>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-default" data-dismiss="modal">{{__ 'BTN_ABORT'}}</button>
+                        <button type="submit" class="btn btn-primary" id="bo-add-cta">{{__ 'BTN_ADD'}}</button>
+                    </div>
+                </form>
+            {{else}}
                 <div class="modal-body">
                     <div class="row">
-                        <div class="col-xs-12" id="addResult"></div>
-                    </div>
-                    <div class="row">
-                        <div class="col-xs-12">
-                            <p>{{__ 'ADD_MODAL_CONTENT'}}</p>
-                        </div>
-                    </div>
-                    <div class="row">
-                        <div class="col-xs-12">
-                            <div class="form-group">
-                                <select name="team" id="team_select" class="form-control"
-                                        required="required">
-                                    <!-- TODO: l10n -->
-                                    <option disabled selected>{{__ 'SELECT_TEAM'}}</option>
-                                    {{#each teams}}
-                                        <option value='{"team": "{{teamId}}", "event": "{{eventId}}"}' {{#weakIfCond ../fromTeam teamId}} selected="selected" {{/weakIfCond}}>
-                                            {{teamName}} ({{teamId}}) ({{eventTitle}})
-                                        </option>
-                                    {{/each}}
-
-                                </select>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="row">
-                        <div class="col-sm-8 hidden-xs">
-                            <div class="form-group">
-                                <label for="amountPerKm_range">{{__ 'LABEL_AMOUNT_KM'}}</label>
-                                <input id="amountPerKm_range" type="range" name="amountPerKm_range" class="form-control"
-                                       min="0.01" max="2" step="0.01"
-                                       value="0.3" required="required">
-                            </div>
-                        </div>
-                        <div class="col-sm-4">
-                            <div class="form-group">
-                                <label for="amountPerKm_text">{{__ 'LABEL_AMOUNT_KM'}}</label>
-                                <input type="text" class="form-control" name="amountPerKm_text"
-                                       id="amountPerKm_text" required="required" value="0.30"
-                                       placeholder="{{__ 'LABEL_AMOUNT_KM'}}">
-                            </div>
-                        </div>
-                    </div>
-                    <div class="row">
-                        <div class="col-xs-12">
-                            <div class="form-group">
-                                <label for="limit">{{__ 'LABEL_LIMIT'}}</label>
-                                <input type="text" class="form-control" name="limit"
-                                       id="limit"
-                                       placeholder="{{__ 'LABEL_LIMIT'}}">
-                            </div>
-                        </div>
-                    </div>
-                    <div class="row">
-                        <div class="col-xs-12">
-                            <div class="well" id="output">
-
-                            </div>
-                            <h4 class="text-right">{{__ 'ESTIMATED_DONATE_PROMISE'}}: <strong><span
-                                    id="estimate"></span>€</strong></h4>
-                        </div>
+                        <div class="col-xs-12">{{__ 'NO_NEW_SPONSORINGS'}}</div>
                     </div>
                 </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-default" data-dismiss="modal">{{__ 'BTN_ABORT'}}</button>
-                    <button type="submit" class="btn btn-primary" id="bo-add-cta">{{__ 'BTN_ADD'}}</button>
-                </div>
-            </form>
+            {{/if}}
         </div>
     </div>
 </div>
@@ -427,69 +436,77 @@
 <div class="modal" id="addChallenge" tabindex="-1" role="dialog" aria-labelledby="addChallengeTitle" {{#weakIfCond mode 1}} data-showReferrer="true" {{/weakIfCond}}>
     <div class="modal-dialog" role="document">
         <div class="modal-content">
-            <form class="form" id="addChallengeForm">
-                <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
-                            aria-hidden="true">&times;</span></button>
-                    <h3 class="modal-title" id="addChallengeTitle">{{__ 'BTN_ADD_CHALLENGE'}}</h3>
-                </div>
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
+                        aria-hidden="true">&times;</span></button>
+                <h3 class="modal-title" id="addChallengeTitle">{{__ 'BTN_ADD_CHALLENGE'}}</h3>
+            </div>
+            {{#if teams.length}}
+                <form class="form" id="addChallengeForm">
+                    <div class="modal-body">
+                        <div class="row">
+                            <div class="col-xs-12" id="addChallengeResult"></div>
+                        </div>
+                        <div class="row">
+                            <div class="col-xs-12">
+                                <p>{{__ 'ADD_CHALLENGE_MODAL_CONTENT'}}</p>
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-xs-12">
+                                <div class="form-group">
+                                    <select name="addChallengeTeam" id="addChallengeTeam" class="form-control" required="required">
+                                        <option disabled selected>{{__ 'SELECT_TEAM'}}</option>
+                                        {{#each teams}}
+                                            <option value='{"team": "{{teamId}}", "event": "{{eventId}}"}' {{#weakIfCond ../fromTeam teamId}} selected="selected" {{/weakIfCond}} >
+                                                {{teamName}} ({{teamId}}) ({{eventTitle}})
+                                            </option>
+                                        {{/each}}
+                                    </select>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="row" id="addChallengeRow">
+                            <div class="col-sm-9">
+                                <div class="form-group has-feedback has-feedback-left">
+                                    <label for="addChallengeDescription">{{__ 'LABEL_CHALLENGE_DESCRIPTION'}}</label>
+                                    <textarea class="form-control" name="addChallengeDescription[]"
+                                              id="addChallengeDescription" required="required"
+                                              placeholder="{{__ 'LABEL_CHALLENGE_DESCRIPTION'}}"></textarea>
+                                    <i class="form-control-feedback material-icons">description</i>
+                                </div>
+                            </div>
+                            <div class="col-sm-3">
+                                <div class="form-group has-feedback has-feedback-left">
+                                    <label for="addChallengeAmount">{{__ 'LABEL_CHALLENGE_AMOUNT'}}</label>
+                                    <input type="text" class="form-control" name="addChallengeAmount[]"
+                                           id="addChallengeAmount" required="required"
+                                           placeholder="{{__ 'LABEL_CHALLENGE_AMOUNT'}}">
+                                    <i class="form-control-feedback material-icons">euro_symbol</i>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-xs-12">
+                                <button type="button" id="addChallengeExtend" class="btn btn-block btn-default">
+                                    {{__ 'ADD_ANOTHER_CHALLENGE'}}
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-default" data-dismiss="modal">{{__ 'BTN_ABORT'}}</button>
+                        <button type="submit" class="btn btn-primary"
+                                id="addChallengeCTA">{{__ 'BTN_ADD_CHALLENGE'}}</button>
+                    </div>
+                </form>
+            {{else}}
                 <div class="modal-body">
                     <div class="row">
-                        <div class="col-xs-12" id="addChallengeResult"></div>
-                    </div>
-                    <div class="row">
-                        <div class="col-xs-12">
-                            <p>{{__ 'ADD_CHALLENGE_MODAL_CONTENT'}}</p>
-                        </div>
-                    </div>
-                    <div class="row">
-                        <div class="col-xs-12">
-                            <div class="form-group">
-                                <select name="addChallengeTeam" id="addChallengeTeam" class="form-control" required="required">
-                                    <option disabled selected>{{__ 'SELECT_TEAM'}}</option>
-                                    {{#each teams}}
-                                        <option value='{"team": "{{teamId}}", "event": "{{eventId}}"}' {{#weakIfCond ../fromTeam teamId}} selected="selected" {{/weakIfCond}} >
-                                            {{teamName}} ({{teamId}}) ({{eventTitle}})
-                                        </option>
-                                    {{/each}}
-                                </select>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="row" id="addChallengeRow">
-                        <div class="col-sm-9">
-                            <div class="form-group has-feedback has-feedback-left">
-                                <label for="addChallengeDescription">{{__ 'LABEL_CHALLENGE_DESCRIPTION'}}</label>
-                                <textarea class="form-control" name="addChallengeDescription[]"
-                                          id="addChallengeDescription" required="required"
-                                          placeholder="{{__ 'LABEL_CHALLENGE_DESCRIPTION'}}"></textarea>
-                                <i class="form-control-feedback material-icons">description</i>
-                            </div>
-                        </div>
-                        <div class="col-sm-3">
-                            <div class="form-group has-feedback has-feedback-left">
-                                <label for="addChallengeAmount">{{__ 'LABEL_CHALLENGE_AMOUNT'}}</label>
-                                <input type="text" class="form-control" name="addChallengeAmount[]"
-                                       id="addChallengeAmount" required="required"
-                                       placeholder="{{__ 'LABEL_CHALLENGE_AMOUNT'}}">
-                                <i class="form-control-feedback material-icons">euro_symbol</i>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="row">
-                        <div class="col-xs-12">
-                            <button type="button" id="addChallengeExtend" class="btn btn-block btn-default">
-                                {{__ 'ADD_ANOTHER_CHALLENGE'}}
-                            </button>
-                        </div>
+                        <div class="col-xs-12">{{__ 'NO_NEW_SPONSORINGS'}}</div>
                     </div>
                 </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-default" data-dismiss="modal">{{__ 'BTN_ABORT'}}</button>
-                    <button type="submit" class="btn btn-primary"
-                            id="addChallengeCTA">{{__ 'BTN_ADD_CHALLENGE'}}</button>
-                </div>
-            </form>
+            {{/if}}
         </div>
 
     </div>
@@ -590,6 +607,7 @@
                         aria-hidden="true">&times;</span></button>
                 <h3 class="modal-title" id="selfModalTitle">{{__ 'HEADER_SELF_SPONSORING'}}</h3>
             </div>
+            {{#if me.participant.event.allowNewSponsoring}}
             <form class="form" id="selfSponsoringModal">
                 <div class="modal-body">
                     <div class="row">
@@ -839,6 +857,13 @@
                             'BTN_SAVE'}}</button>
                 </div>
             </form>
+            {{else}}
+            <div class="modal-body">
+                <div class="row">
+                    <div class="col-xs-12">{{__ 'NO_NEW_SPONSORINGS'}}</div>
+                </div>
+            </div>
+            {{/if}}
         </div>
     </div>
 </div>


### PR DESCRIPTION
Needs backend commits for https://github.com/BreakOutEvent/breakout-backend/issues/207

1. Check for self sponsorings if the event the team is attending allows new sponsorings. Otherwise display a notice in the modal form.
2. Filter the teams sponsors can choose in the add challenge/sponsoring forms. If there are no teams after filtering, display a notice.