### PR TITLE
Fixing profile path

### DIFF
--- a/src/client/js/profile.js
+++ b/src/client/js/profile.js
@@ -109,7 +109,7 @@ $(document).ready(() => {
 
       toggleLoading('#team_CTA');
       $.ajax({
-        url: '/settings/profile/team',
+        url: '/profile/team',
         type: 'PUT',
         cache: false,
         processData: false,


### PR DESCRIPTION
Changing the team data was generating a 400. 

![screen shot 2018-05-18 at 3 11 12 pm](https://user-images.githubusercontent.com/13184158/40236475-f500ade2-5aad-11e8-9db3-057605d0b17b.png)

I wasn't able to test this change, but this is my best guess as to what's wrong.

@florianschmidt1994 please check if I'm not doing some bull💩 