### PR TITLE
Render sponsor settings component even if team registration has closed

### DIFF
--- a/src/client/react/App.jsx
+++ b/src/client/react/App.jsx
@@ -214,6 +214,9 @@ class App extends React.Component {
           <RedirectRegistrationLock exact path={routes.createTeamSuccess}
                         component={this.showModalFor(CreateTeamSuccess, 's')}/>
 
+          <PrivateRoute exact path={routes.profileSettings}
+                        component={this.showComponent(SponsorSettings)}/>
+
         </div>
       </Router>);
     } else {


### PR DESCRIPTION
There was only a route for this part of the router missing.