### PR TITLE
Fix the gravity to the face for create posting card

### DIFF
--- a/src/server/views/dynamic/team/team-detail.handlebars
+++ b/src/server/views/dynamic/team/team-detail.handlebars
@@ -82,7 +82,7 @@
                                         <div class="bo-card-profilePic"
                                              style="background-image: url(
                                                  {{#if user.profilePic.url}}
-                                                     {{user.profilePic.url}}
+                                                    {{transform 'c_fill,g_faces,h_400,w_400' user.profilePic.url}}
                                                  {{else}}
                                                  '../img/placeholder_profile_pic.jpg'
                                                  {{/if}});"></div>


### PR DESCRIPTION
This fix moves the gravity to the face in the card where
a new posting is created.

*Before*
<img width="443" alt="Screenshot 2019-05-11 at 12 44 57" src="https://user-images.githubusercontent.com/6798306/57568797-67a73c00-73ec-11e9-9f55-5fafa0bc4115.png">

*After*
<img width="443" alt="Screenshot 2019-05-11 at 12 44 57" src="https://user-images.githubusercontent.com/6798306/57568805-83aadd80-73ec-11e9-892f-83cf0472104a.png">



