### PR TITLE
Change remaining OneDollarGlasses to Zeltschule in translations

### DIFF
--- a/src/common/resources/translations/translations.de.js
+++ b/src/common/resources/translations/translations.de.js
@@ -39,25 +39,25 @@ module.exports = {
       "supporterData": {
         "title": "Spender-/Sponsordaten",
         "selectionText": "Im folgenden können Sie auswählen, in welcher Form Sie ein oder mehrere Teams und damit" +
-        "unseren Spendenpartner OneDollarGlasses e. V. unterstützen wollen.",
+        "unseren Spendenpartner Zeltschule e. V. unterstützen wollen.",
         "selectionLabel": "Art der Unterstützung",
         "donor": {
           "title": "Spender",
-          "description": "Als Spender wandern 100% des gespendeten Geldes an den EinDollarGlasses e. V. und es wird Ihnen " +
+          "description": "Als Spender wandern 100% des gespendeten Geldes an den Zeltschule e. V. und es wird Ihnen " +
           "vom BreakOut e. V. eine Spendenquittung oder ein (vereinfachter) Spendennachweis ausgestellt."
         },
         "passive": {
           "title": "Passiver Sponsor",
           "description": "Als passiver Sponsor können Sie Ihren Firmennamen sowie ein Logo auf der Website platzieren. " +
           "Sie bekommen vom BreakOut e. V. eine Rechnung ausgestellt, aber es wird keine Umsatzsteuer fällig. 100% des " +
-          "Betrags gehen an den EinDollarGlasses e. V."
+          "Betrags gehen an den Zeltschule e. V."
         },
         "active": {
           "title": "Aktiver Sponsor",
           "description": "Als aktiver Sponsor können Sie Ihren Firmennamen, einen Link zur Firmenwebsite sowie optional " +
           "ein Logo hochgeladen werden. Sie bekommen vom BreakOut e. V. dann eine Rechnung ausgestellt, auf der eine " +
           "Umsatzsteuer von 19% ausgewiesen wird. Der bezahlte Betrag, abzüglich der Umsatzsteuer, geht vollständig an " +
-          "den EinDollarGlasses e. V."
+          "den Zeltschule e. V."
         },
       },
       "company": "Firma",
@@ -351,7 +351,7 @@ module.exports = {
     "ELEMENT_2": "Starterkit",
     "ELEMENT_3": "BreakOut Hotline",
     "DESCRIPTION_2": "Alle diese Posten fließen direkt oder indirekt wieder an Euch zurück. Eure Sicherheit steht für uns an erster Stelle, weshalb die BreakOut Hotline die ganzen 36 Stunden für Euch erreichbar sein wird.",
-    "DESCRIPTION_3": "Da der Grundgedanke von BreakOut das Spenden an den EinDollarBrille e. V. ist, möchten wir sicherstellen, dass jedes Team diesen sozialen Gedanken unterstützt. Wir erheben deshalb 20€ Kaution pro Team. Diese überweisen wir Euch nach dem Event zurück, wenn Ihr über 100€ an Spenden generiert habt. Andernfalls gehen die 20€ in Eurem Namen direkt an den EinDollarBrille e.V. Aber keine Panik, das kriegt Ihr locker hin! <3",
+    "DESCRIPTION_3": "Da der Grundgedanke von BreakOut das Spenden an den Zeltschule e. V. ist, möchten wir sicherstellen, dass jedes Team diesen sozialen Gedanken unterstützt. Wir erheben deshalb 20€ Kaution pro Team. Diese überweisen wir Euch nach dem Event zurück, wenn Ihr über 100€ an Spenden generiert habt. Andernfalls gehen die 20€ in Eurem Namen direkt an den Zeltschule e.V. Aber keine Panik, das kriegt Ihr locker hin! <3",
     "DESCRIPTION_4": "Das heißt die Gesamtkosten pro Team betragen 60,-€ (20€ Anmeldegebühr pro Person + 20€ Spendendeposit). Für eine erfolreiche Anmeldung muss der Gesamtbetrag bis zum 25. Mai 2019 überwiesen worden sein. Nutzt hierfür den <strong>angegebenen Verwendungszweck</strong> und folgende Kontoverbindung:",
     "SUBHEADLINE_1": "Überweisung",
     "ACCNUMBER": "IBAN",
@@ -535,7 +535,7 @@ module.exports = {
   },
   "LIVEBLOG": {
     "HEADLINE": "Was ist BreakOut?",
-    "DESCRIPTION": "Bei BreakOut versuchen Teams von je zwei Personen innerhalb von 36 Stunden so weit wie möglich vom Ausgangspunkt (München, Berlin oder Barcelona) weg zu reisen, ohne Geld für die Fortbewegung auszugeben. Jedes Team sucht Sponsoren, die - pro Kilometer oder für die Erfüllung gestellter Aufgaben (Challenges), einen gewissen Betrag für den EinDollarBrille e. V. spenden.",
+    "DESCRIPTION": "Bei BreakOut versuchen Teams von je zwei Personen innerhalb von 36 Stunden so weit wie möglich vom Ausgangspunkt (München, Berlin oder Barcelona) weg zu reisen, ohne Geld für die Fortbewegung auszugeben. Jedes Team sucht Sponsoren, die - pro Kilometer oder für die Erfüllung gestellter Aufgaben (Challenges), einen gewissen Betrag für den Zeltschule e. V. spenden.",
     "TIME_H": "BreakOut Event",
     "TIME_PRE": "Bis BreakOut startet",
     "TIME_DURING": "Bis BreakOut endet",

--- a/src/common/resources/translations/translations.en.js
+++ b/src/common/resources/translations/translations.en.js
@@ -42,24 +42,24 @@ module.exports = {
       "supporterData": {
         "title": "Supporter data",
         "selectionText": "You can choose which type of supporter you will be in order to support our partner" +
-        "OneDollarGlasss e.V.",
+        "Zeltschule e.V.",
         "selectionLabel": "Type of support",
         "donor": {
           "title": "Donor",
-          "description": "As donor 100% of your donation will be transferred to OneDollarGlasses e. V. and you " +
+          "description": "As donor 100% of your donation will be transferred to Zeltschule e. V. and you " +
           "will get a receipt or a (simplified) proof of donation from BreakOut e.V."
         },
         "passive": {
           "title": "Passive sponsor",
           "description": "As passive sponsor you are allowed to place your company's name and logo on our website. " +
           "You will get an invoice from BreakOut e.V. but you don't have to pay turnover tax. Thus 100% of your " +
-          "donation will be transferred to OneDollarGlasses e.V."
+          "donation will be transferred to Zeltschule e.V."
         },
         "active": {
           "title": "Active sponsor",
           "description": "As active sponsor you are allowed to place your company's name, website url and optionally " +
           "logo on our website. You will get an invoice from BreakOut e.V. including 19% of turnover tax. The " +
-          "remaining donation will be transferred to OneDollarGlasses e.V."
+          "remaining donation will be transferred to Zeltschule e.V."
         },
       },
       "company": "Company",
@@ -349,7 +349,7 @@ module.exports = {
     "ELEMENT_2": "Starter-kit",
     "ELEMENT_3": "BreakOut Hotline",
     "DESCRIPTION_2": "All of these come back to you directly or indirectly. Your safety is of utmost importance to us, that is why the BreakOut Hotline will be available throughout the entire 36 hours.",
-    "DESCRIPTION_3": "Since the idea behind BreakOut is to give donations to One Dollar Glasses, we want to make sure that every team supports this social idea. Therefore you are required to give a deposit of 20€. You will get it back after the event, if your team has generated more than 100€ in donations. Otherwise the 20€ will go directly to One Dollar Glasses in your name. But don't worry, the goal is easily reached! <3",
+    "DESCRIPTION_3": "Since the idea behind BreakOut is to give donations to Zeltschule, we want to make sure that every team supports this social idea. Therefore you are required to give a deposit of 20€. You will get it back after the event, if your team has generated more than 100€ in donations. Otherwise the 20€ will go directly to Zeltschule e. V. in your name. But don't worry, the goal is easily reached! <3",
     "DESCRIPTION_4": "So the total amount per term is 60€ (20€ Registration per person + 20€ Deposit). For a succesful registration the total amount has to be transferred by 25th May 2019. Please use the <strong>mentioned purpose</strong> and the following bank account:",
     "SUBHEADLINE_1": "Transfer",
     "ACCNUMBER": "IBAN",


### PR DESCRIPTION
There are a couple of places where our previous donation partner
OneDollarGlasses was still mentioned instead of Zeltschule e. V.
as the current one. This changes those translations.