### PR TITLE
Fix overflow on team page

### DIFF
--- a/src/client/less/_teampage.less
+++ b/src/client/less/_teampage.less
@@ -284,7 +284,8 @@
   position: absolute;
   top: 15px;
   right: 25px;
-  width: 10px;
+  width: 20px;
+  overflow-x: hidden;
   text-shadow: -1px 0 #fff, 0 1px #fff, 1px 0 #fff, 0 -1px #fff;
 
   i {


### PR DESCRIPTION
This fixes an overflow on the team page. For some reason
(I suspect the text backing the icon) the delete icon on
postings causes an overflow, which also leads to the navbar
being wider than the screen.

Hiding this overflow and making the icon a little wider to
display it fully solves this problem.