### PR TITLE
Display correct team name on old profiles

### DIFF
--- a/src/server/controller/TeamController.js
+++ b/src/server/controller/TeamController.js
@@ -242,7 +242,11 @@ TeamController.getTeamByUrl = (teamId, token) => co(function* () {
   let postings = responses[4];
   let locations = responses[5];
 
-  tempTeam.postings = postings;
+  tempTeam.postings = postings.map(p => {
+    p.teamId = tempTeam.id;
+    p.teamName = tempTeam.name;
+    return p;
+  });
 
   tempTeam.event = events
     .filter((event) => event.id === tempTeam.event)

--- a/src/server/views/partials/team-posting.handlebars
+++ b/src/server/views/partials/team-posting.handlebars
@@ -13,7 +13,7 @@
             </div>
             <div class="col-xs-9">
                 <div class="bo-card-info-name">
-                    <span class="bo-card-info-headline"><a href="/team/{{user.participant.teamId}}" class="no-underline">{{user.participant.teamName}}</a> </span>
+                    <span class="bo-card-info-headline"><a href="/team/{{teamId}}" class="no-underline">{{teamName}}</a> </span>
                     <a href="/post/{{id}}" class="bo-card-info-sub no-underline">{{user.firstname}} {{relativeTime date}}{{prettyLocation postingLocation.locationData}}</a>
                 </div>
             </div>


### PR DESCRIPTION
This fixes the issue that on an old profile the name of a users
current team would be displayed on top of the cards instead of the
correct one.

This does not fix the issue for the card that creates a new posting,
see https://github.com/BreakOutEvent/breakout-frontend/issues/353