### PR TITLE
Fix an overflow that happens for some long challenge descriptions

### DIFF
--- a/src/client/less/_teampage.less
+++ b/src/client/less/_teampage.less
@@ -180,6 +180,10 @@
   margin-top: 40px;
 }
 
+.bo-team-post {
+  max-width: 100%;
+}
+
 #bo-team-location {
   padding-top: 10px;
   text-align: center;


### PR DESCRIPTION
See title. I verified this on iPhone X and macOS on full width. Fixes the edge-case and leaves the other stuff unchanged