### PR TITLE
Clean up /settings/sponsoring views

### DIFF
--- a/src/server/views/dynamic/sponsoring/sponsoring.handlebars
+++ b/src/server/views/dynamic/sponsoring/sponsoring.handlebars
@@ -51,12 +51,13 @@
             </div>
             <div id="result_in"></div>
             <h3>Sponsorings</h3>
-            <table class="table table-striped">
+            <table class="table table-striped table-bordered">
                 <thead>
                 <tr>
                     <th>Sponsor</th>
                     <th>Euro pro KM</th>
                     <th>Limit</th>
+                    <th>Status</th>
                 </tr>
                 </thead>
                 <tbody>
@@ -95,14 +96,14 @@
                                         <button class="btn btn-danger bo-btn-delete" data-team="{{teamId}}"
                                                 data-sponsoring="{{id}}" data-event="{{eventId}}">{{__ 'BTN_DELETE'}}</button>
                                     {{else}}
-                                        <span class="text-success">{{__ 'STATUS_ACCEPTED'}}</span>
+                                        <span class="label label-success">{{__ 'STATUS_ACCEPTED'}}</span>
                                     {{/if}}
                                 {{/ifCond}}
                                 {{#ifCond status "REJECTED"}}
-                                    <span class="text-danger">{{__ 'STATUS_REJECTED'}}</span>
+                                    <span class="label label-danger">{{__ 'STATUS_REJECTED'}}</span>
                                 {{/ifCond}}
                                 {{#ifCond status "WITHDRAWN"}}
-                                    <span class="text-danger">{{__ 'STATUS_WITHDRAWN'}}</span>
+                                    <span class="label label-danger">{{__ 'STATUS_WITHDRAWN'}}</span>
                                 {{/ifCond}}
                             {{/ifCond}}
                         </td>
@@ -111,19 +112,20 @@
                 </tbody>
             </table>
             <h3>Challenges</h3>
-            <table class="table table-striped">
+            <table class="table table-striped table-bordered">
                 <thead>
                 <tr>
                     <th>Sponsor</th>
                     <th>{{__ 'DESCRIPTION' }}</th>
                     <th>{{__ 'MAXIMUM_COUNT' }}</th>
                     <th>Euro</th>
+                    <th>Status</th>
                 </tr>
                 </thead>
                 <tbody>
                 {{#unless incChallenges}}
                     <tr>
-                        <td colspan="4"><i>No challenges found</i></td>
+                        <td colspan="5"><i>No challenges found</i></td>
                     </tr>
                 {{/unless}}
                 {{#each incChallenges}}
@@ -162,10 +164,10 @@
                                 {{/if}}
                             {{/ifCond}}
                             {{#ifCond status "REJECTED"}}
-                                <span class="text-danger">{{__ 'STATUS_REJECTED'}}</span>
+                                <span class="label label-danger">{{__ 'STATUS_REJECTED'}}</span>
                             {{/ifCond}}
                             {{#ifCond status "WITHDRAWN"}}
-                                <span class="text-danger">{{__ 'STATUS_WITHDRAWN'}}</span>
+                                <span class="label label-danger">{{__ 'STATUS_WITHDRAWN'}}</span>
                             {{/ifCond}}
                         </td>
                     </tr>
@@ -199,19 +201,20 @@
                 <div class="row">
                     <div class="col-xs-12">
                         <h3>Sponsorings</h3>
-                        <table class="table table-striped">
+                        <table class="table table-striped table-bordered">
                             <thead>
                             <tr>
                                 <th>Team ID</th>
                                 <th>Team Name</th>
                                 <th>Euro pro KM</th>
                                 <th>Limit</th>
+                                <th>Status</th>
                             </tr>
                             </thead>
                             <tbody>
                             {{#unless outSponsoring}}
                                 <tr>
-                                    <td colspan="4"><i>No sponsorings found</i></td>
+                                    <td colspan="5"><i>No sponsorings found</i></td>
                                 </tr>
                             {{/unless}}
                             {{#each outSponsoring}}
@@ -230,7 +233,7 @@
                                             data-target="#editSponsoring">{{__ 'BTN_EDIT'}}</button>-->
 
                                         {{#ifCond status "WITHDRAWN"}}
-                                            <span class="text-danger">{{__ 'STATUS_WITHDRAWN'}}</span>
+                                            <span class="label label-danger">{{__ 'STATUS_WITHDRAWN'}}</span>
                                         {{else}}
                                             <button class="btn btn-danger bo-btn-delete" data-team="{{teamId}}"
                                                     data-sponsoring="{{id}}" data-event="{{eventId}}">{{__ 'BTN_DELETE'}}</button>
@@ -241,7 +244,7 @@
                             </tbody>
                         </table>
                         <h3>Challenges</h3>
-                        <table class="table table-striped">
+                        <table class="table table-striped table-bordered">
                             <thead>
                             <tr>
                                 <th>Team ID</th>
@@ -249,12 +252,13 @@
                                 <th>{{__ 'DESCRIPTION' }}</th>
                                 <th>{{__ 'MAXIMUM_COUNT' }}</th>
                                 <th>Euro</th>
+                                <th>Status</th>
                             </tr>
                             </thead>
                             <tbody>
                             {{#unless outChallenges}}
                                 <tr>
-                                    <td colspan="4"><i>No challenges found</i></td>
+                                    <td colspan="6"><i>No challenges found</i></td>
                                 </tr>
                             {{/unless}}
                             {{#each outChallenges}}
@@ -277,7 +281,7 @@
                                     <td>{{displayCurrency amount}} €</td>
                                     <td class="text-right">
                                         {{#ifCond status "WITHDRAWN"}}
-                                            <span class="text-danger">{{__ 'STATUS_WITHDRAWN'}}</span>
+                                            <span class="label label-danger">{{__ 'STATUS_WITHDRAWN'}}</span>
                                         {{else}}
                                             <button class="btn btn-danger challengeDelete" data-team="{{teamId}}"
                                                     data-id="{{id}}" data-event="{{eventId}}">{{__ 'BTN_DELETE'}}</button>
@@ -304,7 +308,7 @@
             <div id="result_in"></div>
             <h3>{{__ 'NAVIGATION_RESULT'}}</h3>
 
-            <table class="table table-striped">
+            <table class="table table-striped table-bordered">
                 <thead>
                 <tr>
                     <th>{{__ 'HAS_PAID'}}</th>
@@ -356,7 +360,7 @@
 
                   <h4>{{__ 'INVOICE_OVERVIEW'}}</h4>
 
-                  <table class="table table-striped text-left" style="min-width: 450px; width: 50%">
+                  <table class="table table-striped table-bordered text-left" style="min-width: 450px; width: 50%">
                       <tr>
                           <td>{{__ 'RECIPIENT'}}</td>
                           <td>BreakOut e.V.</td>
@@ -398,7 +402,7 @@
 
                   <h4>Challenges</h4>
 
-                  <table class="table table-striped">
+                  <table class="table table-striped table-bordered">
                       <thead>
                       <tr>
                           <th>Team</th>
@@ -426,7 +430,7 @@
 
                   <h4>Sponsorings</h4>
 
-                  <table class="table table-striped">
+                  <table class="table table-striped table-bordered">
                       <thead>
                       <tr>
                           <th>Team</th>


### PR DESCRIPTION
This introduces two challenges

1.) All withdrawn / accepted texts will be a bootstrap label instead of text
2.) Tables will be bordered on the outside

Just a little cleanup that I thought would look good

*Before*
![image](https://user-images.githubusercontent.com/6798306/57571759-3d687500-7412-11e9-8d4b-6c4adc7cc68b.png)

*After*
![image](https://user-images.githubusercontent.com/6798306/57571757-36416700-7412-11e9-96ae-774f2cb1fb34.png)
