### PR TITLE
Fix logo deletion

### DIFF
--- a/src/client/react/Components/Sponsor/SponsorInformation.jsx
+++ b/src/client/react/Components/Sponsor/SponsorInformation.jsx
@@ -281,7 +281,7 @@ class SponsorInformation extends React.Component {
               {logo && logo.url && <img src={logo.url} style={styles.logoPreview} />}
               {logo && <IconButton onClick={event => {
                 event.persist();
-                this.setState(state => ({me: {...state.me, sponsor: {...state.me.sponsor, logo: 'DELETE'}}}));
+                this.setState(state => ({me: {...state.me, sponsor: {...state.me.sponsor, logo: undefined}}}));
               }} aria-label="Delete">
                 <Delete fontSize="small" />
               </IconButton>}


### PR DESCRIPTION
When deleting the sponsor's logo, the logo must be unset in the state, to call the delete endpoint.