### PR TITLE
Improve docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+secrets.zip.enc
+config-prod.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,17 @@
-FROM mhart/alpine-node:10
-RUN apk add --no-cache git bash make gcc g++ python
+FROM node:16-alpine
 
-COPY . /frontend
 WORKDIR /frontend
 
-RUN npm install
-RUN npm run build
 RUN npm install -g forever
+
+COPY package.json /frontend
+COPY package-lock.json /frontend
+
+RUN npm ci
+
+COPY . /frontend
+
+RUN npm run build
 
 ENV NODE_ENVIRONMENT prod
 

--- a/config-template.json
+++ b/config-template.json
@@ -6,11 +6,11 @@
     "protocol": "https"
   },
   "db": {
-    "user": "user",
-    "password": "password",
-    "url": "url",
-    "port": 123456,
-    "name": "name"
+    "user": "root",
+    "password": "example",
+    "url": "mongo",
+    "port": 27017,
+    "name": "admin"
   },
   "cluster": "false",
   "secret": "secret-cat",
@@ -35,5 +35,7 @@
     "cloud_name": "fill",
     "api_key": "me",
     "api_secret": "in"
-  }
+  },
+  "space": "contentful-space",
+  "accessToken": "contentful-token"
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: "3.9"
+services:
+  breakout-frontend:
+    build: .
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./config-prod.json:/frontend/config-prod.json
+    networks:
+      - network
+  breakout-mongo:
+    image: mongo
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: root
+      MONGO_INITDB_ROOT_PASSWORD: example
+    ports:
+      - "27017:27017"
+    networks:
+      - network
+networks:
+  network:


### PR DESCRIPTION
* currently `npm install` seems to install some newer dependencies than the code was developed for, which prevents the login/register dialog from showing up. `npm ci` installs the dependencies as they are in the package-lock.json to fix this
* speed up build process by moving `npm ci` above the copy source command
* update Node to current LTS version 16 and use official images
* drop installation of gcc, python, ... whatever since it doesn't seem necessary