### PR TITLE
Fix styles CSS import

### DIFF
--- a/src/server/views/layouts/funnel.handlebars
+++ b/src/server/views/layouts/funnel.handlebars
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Anmeldung zu BreakOut 2019</title>
-    <link href="js/styles.css" rel="stylesheet">
+    <link href="/js/styles.css" rel="stylesheet">
 
     <meta name="theme-color" content="#d97908">
 


### PR DESCRIPTION
Fixes e.g. activation page (`https://break-out.org/activation/<token>`) not having any CSS styles applied.