### PR TITLE
Add button to delete own comments, improve delete button accessibility

### DIFF
--- a/src/client/js/team.js
+++ b/src/client/js/team.js
@@ -282,7 +282,7 @@ $(window).on('load', function () {
     $(this).html(wrapped);
   });
 
-  $('.bo-admin-delete').on('click', function () {
+  $('.bo-btn-delete').on('click', function () {
     var type = $(this).attr('data-delete-type');
     var id = parseInt($(this).attr('data-id'));
     var postingId = $(this).attr('data-posting-id');
@@ -295,7 +295,6 @@ $(window).on('load', function () {
           posting: postingId
         },
         success: function () {
-          alert('DELETED!');
           window.location.reload();
         },
         error: function () {

--- a/src/client/less/_teampage.less
+++ b/src/client/less/_teampage.less
@@ -286,7 +286,7 @@
   color: #999;
 }
 
-.bo-admin-delete {
+.bo-btn-delete {
   color: @brand-danger;
   position: absolute;
   top: 15px;
@@ -294,6 +294,10 @@
   width: 20px;
   overflow-x: hidden;
   text-shadow: -1px 0 #fff, 0 1px #fff, 1px 0 #fff, 0 -1px #fff;
+  border: 0;
+  margin: 0;
+  padding: 0;
+  background: none;
 
   i {
     width: 20px;

--- a/src/server/controller/TeamController.js
+++ b/src/server/controller/TeamController.js
@@ -65,7 +65,7 @@ class TeamController {
     return res.sendStatus(500);
   }
 
-  static* deleteOwnPosting(req, res, next) {
+  static* deleteOwnPosting(req, res) {
     if (req.params.postingId && req.params.postingId !== '') {
       const posting = yield api.posting.getPosting(req.params.postingId);
       logger.info('Trying to delete posting from user ', posting.user.id);
@@ -146,6 +146,22 @@ class TeamController {
       const postingId = req.body.posting;
       yield api.admin.deleteComment(req.user, req.params.commentId, postingId);
       return res.sendStatus(200);
+    }
+    return res.sendStatus(500);
+  }
+
+  static* deleteOwnComment(req, res) {
+    const commentId = req.params.commentId;
+    if (commentId && commentId !== '') {
+      const postingId = req.body.posting;
+      const posting = yield api.posting.getPosting(postingId);
+      if(posting && posting.comments) {
+        const comment = posting.comments.find(x => x.id == commentId); // must be == due to string/number comparison
+        if (comment && comment.user && comment.user.id === req.user.me.id) {
+          yield api.admin.deleteComment(req.user, commentId, postingId);
+          return res.sendStatus(200);
+        }
+      }
     }
     return res.sendStatus(500);
   }

--- a/src/server/routes/team.js
+++ b/src/server/routes/team.js
@@ -37,4 +37,6 @@ router.delete('/media/:mediaId', session.isEventManager, TeamController.deleteMe
 
 router.delete('/comment/:commentId', session.isEventManager, TeamController.deleteComment);
 
+router.delete('/mycomment/:commentId', session.isUser, TeamController.deleteOwnComment);
+
 module.exports = router;

--- a/src/server/views/partials/team-comment.handlebars
+++ b/src/server/views/partials/team-comment.handlebars
@@ -29,10 +29,15 @@
     </div>
 
     {{#if isUserAdmin}}
-        <div class="bo-admin-delete" data-delete-type="comment" data-id="{{id}}" data-posting-id="{{posting-id}}">
+        <button class="bo-btn-delete" data-delete-type="comment" data-id="{{id}}" data-posting-id="{{posting-id}}">
             <i class="material-icons bo-card-actions-icon">delete forever</i>
-        </div>
+        </button>
     {{/if}}
+    {{#ifCond user.id currentUserId}}
+        <button class="bo-btn-delete" data-delete-type="mycomment" data-id="{{id}}" data-posting-id="{{posting-id}}">
+            <i class="material-icons bo-card-actions-icon">delete forever</i>
+        </button>
+    {{/ifCond}}
 </div>
 
 

--- a/src/server/views/partials/team-posting.handlebars
+++ b/src/server/views/partials/team-posting.handlebars
@@ -19,14 +19,14 @@
             </div>
         </div>
         {{#if isUserAdmin}}
-            <div class="bo-admin-delete" data-delete-type="posting" data-id="{{id}}" data-posting-id="{{id}}">
+            <button class="bo-btn-delete" data-delete-type="posting" data-id="{{id}}" data-posting-id="{{id}}">
                 <i class="material-icons bo-card-actions-icon">delete forever</i>
-            </div>
+            </button>
         {{/if}}
         {{#ifCond user.id currentUserId}}
-            <div class="bo-admin-delete" data-delete-type="myposting" data-id="{{id}}" data-posting-id="{{id}}">
+            <button class="bo-btn-delete" data-delete-type="myposting" data-id="{{id}}" data-posting-id="{{id}}">
                 <i class="material-icons bo-card-actions-icon">delete forever</i>
-            </div>
+            </button>
         {{/ifCond}}
     </div>
     <div class="bo-card-media">
@@ -128,7 +128,7 @@
     </div>
     <div class="bo-card-comments">
         {{#each comments}}
-            {{> team-comment isUserAdmin=../isUserAdmin posting-id=../id}}
+            {{> team-comment isUserAdmin=../isUserAdmin posting-id=../id currentUserId=../currentUserId}}
         {{/each}}
         <div class="bo-card-comment-new">
             <form class="newComment">


### PR DESCRIPTION
* remove "DELETED!" alert after successful deletion
* make delete buttons actual buttons. Divs with onClick don't provide a good accessibility.
* lazily add new deleteOwnComment route. Ideally we'd just have one single route checking either manager permission or whether a user is logged in, but I just used the present approaches (see deleteOwnPosting)